### PR TITLE
`array_to_image` is now part of `spikeinterface.widgets`

### DIFF
--- a/examples/spikeinterface_example.py
+++ b/examples/spikeinterface_example.py
@@ -3,6 +3,7 @@ import os
 
 import spikeinterface as si
 import spikeinterface.toolkit as st
+import spikeinterface.widgets as sw
 
 from figurl_tiled_image import TiledImage
 
@@ -50,7 +51,7 @@ def convert_and_upload(processing_steps, labels, start_frame, num_samples):
         else:
             color_range = 250
         
-        img = st.array_to_image(arr, 
+        img = sw.array_to_image(arr, 
                                 color_range=color_range,
                                 num_timepoints_per_row = 6000)
         


### PR DESCRIPTION
The array generation function now lives in `spikeinterface.widgets`, so an extra import is required.